### PR TITLE
X00TD: drop debug.hwui.use_buffer_age

### DIFF
--- a/vendor.prop
+++ b/vendor.prop
@@ -106,7 +106,6 @@ dalvik.vm.heapminfree=512k
 dalvik.vm.heapmaxfree=8m
 
 # Display
-debug.hwui.use_buffer_age=false
 debug.sf.enable_hwc_vds=1
 debug.sf.enable_gl_backpressure=1
 debug.hwui.renderer=skiagl


### PR DESCRIPTION
Fixes lags after QPR1 merge